### PR TITLE
Enabled conv_test and disabling miopen cache

### DIFF
--- a/docker/ubuntu-16.04-rocm171/Dockerfile
+++ b/docker/ubuntu-16.04-rocm171/Dockerfile
@@ -73,7 +73,7 @@ ARG PATH=$HCC_HOME/bin:$HIP_PATH/bin:$PATH
 
 RUN cd /root/MLOpen && cmake -P install_deps.cmake && \
     mkdir -p build && cd build && \
-    CXX=/opt/rocm/hcc/bin/hcc cmake -DMIOPEN_BACKEND=HIP -DCMAKE_PREFIX_PATH="/opt/rocm/hcc;/opt/rocm/hip" -DCMAKE_CXX_FLAGS="-isystem /usr/include/x86_64-linux-gnu/" .. && \
+    CXX=/opt/rocm/hcc/bin/hcc cmake -DMIOPEN_CACHE_DIR="" -DMIOPEN_BACKEND=HIP -DCMAKE_PREFIX_PATH="/opt/rocm/hcc;/opt/rocm/hip" -DCMAKE_CXX_FLAGS="-isystem /usr/include/x86_64-linux-gnu/" .. && \
     make -j $(nproc) && make install
 
 WORKDIR $HOME

--- a/tests/python_tests.sh
+++ b/tests/python_tests.sh
@@ -3,8 +3,7 @@ rm -r ../caffe2/python/operator_test/__*
 
 failed_tests=()
 passed_tests=()
-ignore_tests=("conv_test.py",
-			  "cudnn_recurrent_test.py",
+ignore_tests=("cudnn_recurrent_test.py",
 			  "deform_conv_test.py",
 			  "elementwise_op_broadcast_test.py",
 			  "gru_test.py",


### PR DESCRIPTION
Disabling miopen cache in the docker as it is raising permission issues in the nightly test runs.